### PR TITLE
Add viterbi matrix plotting functions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 numpy~=1.24.4
+black
+black[jupyter]
+plotly

--- a/tests.ipynb
+++ b/tests.ipynb
@@ -31,7 +31,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def viterbi_logprobs(A: np.array, B: np.array, PI: np.array) -> Tuple[np.array, list, float]:\n",
+    "def viterbi_logprobs(\n",
+    "    A: np.array, B: np.array, PI: np.array\n",
+    ") -> Tuple[np.array, list, float]:\n",
     "    \"\"\"\n",
     "    A: transition matrix -> NxN where N is the number of states that can occur (e.g. Noun, Verbs, Adjectives, etc)\n",
     "    B: observation matrix (probability that a word belongs to state) -> NxT where T is the length of the sentence.\n",
@@ -42,19 +44,19 @@
     "    T = B.shape[1]\n",
     "    viterbi = np.full((N, T), -np.inf)\n",
     "    backpointer = []\n",
-    "    \n",
+    "\n",
     "    # initialization step\n",
-    "    viterbi[:,0] = PI[0] + B[:,0]\n",
-    "    best_arg = np.argmax(viterbi[:,0])\n",
+    "    viterbi[:, 0] = PI[0] + B[:, 0]\n",
+    "    best_arg = np.argmax(viterbi[:, 0])\n",
     "    backpointer.append(best_arg)\n",
-    "    \n",
+    "\n",
     "    for i in range(1, T):\n",
-    "        viterbi[:,i] = viterbi[backpointer[-1], i-1] + A[backpointer[-1]] + B[:,i]\n",
-    "        best_arg = np.argmax(viterbi[:,i])\n",
+    "        viterbi[:, i] = viterbi[backpointer[-1], i - 1] + A[backpointer[-1]] + B[:, i]\n",
+    "        best_arg = np.argmax(viterbi[:, i])\n",
     "        backpointer.append(best_arg)\n",
     "\n",
     "    best_logprobability = np.max(viterbi[:, -1])\n",
-    "    \n",
+    "\n",
     "    return viterbi, backpointer, best_logprobability"
    ]
   },
@@ -66,20 +68,26 @@
    "outputs": [],
    "source": [
     "# Toy example from the slides, take into account they are considered to be log probabilities\n",
-    "PI = np.array([\n",
-    "    # N, V\n",
-    "    [-1, -2]\n",
-    "])\n",
-    "A = np.array([\n",
-    "    # N,  V, \n",
-    "    [-3, -1], # N\n",
-    "    [-1, -3] # V\n",
-    "])\n",
-    "B = np.array([\n",
-    "    # they can fish\n",
-    "    [-2,-3,-3], # N\n",
-    "    [-10,-1,-3] # V\n",
-    "])\n",
+    "PI = np.array(\n",
+    "    [\n",
+    "        # N, V\n",
+    "        [-1, -2]\n",
+    "    ]\n",
+    ")\n",
+    "A = np.array(\n",
+    "    [\n",
+    "        # N,  V,\n",
+    "        [-3, -1],  # N\n",
+    "        [-1, -3],  # V\n",
+    "    ]\n",
+    ")\n",
+    "B = np.array(\n",
+    "    [\n",
+    "        # they can fish\n",
+    "        [-2, -3, -3],  # N\n",
+    "        [-10, -1, -3],  # V\n",
+    "    ]\n",
+    ")\n",
     "sentence = \"they can fish\""
    ]
   },
@@ -104,7 +112,7 @@
     }
    ],
    "source": [
-    "viterbi_logprobs(A,B, PI)"
+    "viterbi_logprobs(A, B, PI)"
    ]
   },
   {
@@ -115,23 +123,27 @@
    "outputs": [],
    "source": [
     "# Toy example from the slides, take into account they are considered to be log probabilities\n",
-    "PI = np.array([-1, -3, -3, -4 ,-4])\n",
-    "A = np.array([\n",
-    "    # ADJ, ADV, DET, NOUN, VERB\n",
-    "    [-3, -4,-np.inf, -2, -3],       # ADJ\n",
-    "    [-3, -3, -4,      -4, -3],      # ADV\n",
-    "    [-2,-4,-np.inf, -0.5, -4],      # DET\n",
-    "    [-4,-4, -4,       -3, -2],       # NOUN\n",
-    "    [-3, -2, -4,      -3, -np.inf]  # VERB\n",
-    "])\n",
-    "B = np.array([\n",
-    "    # the aged bottle flies fast\n",
-    "    [-np.inf, -2, -np.inf, -np.inf, -2],      # ADJ\n",
-    "    [-np.inf,-np.inf,-np.inf,-np.inf, -1],    # ADV\n",
-    "    [-1, -np.inf,-np.inf,-np.inf,-np.inf],    # DET\n",
-    "    [-np.inf, -np.inf,-2, -3, -5],            # NOUN\n",
-    "    [-np.inf, -5, -2, -3, -2]                 # VERB\n",
-    "])\n",
+    "PI = np.array([-1, -3, -3, -4, -4])\n",
+    "A = np.array(\n",
+    "    [\n",
+    "        # ADJ, ADV, DET, NOUN, VERB\n",
+    "        [-3, -4, -np.inf, -2, -3],  # ADJ\n",
+    "        [-3, -3, -4, -4, -3],  # ADV\n",
+    "        [-2, -4, -np.inf, -0.5, -4],  # DET\n",
+    "        [-4, -4, -4, -3, -2],  # NOUN\n",
+    "        [-3, -2, -4, -3, -np.inf],  # VERB\n",
+    "    ]\n",
+    ")\n",
+    "B = np.array(\n",
+    "    [\n",
+    "        # the aged bottle flies fast\n",
+    "        [-np.inf, -2, -np.inf, -np.inf, -2],  # ADJ\n",
+    "        [-np.inf, -np.inf, -np.inf, -np.inf, -1],  # ADV\n",
+    "        [-1, -np.inf, -np.inf, -np.inf, -np.inf],  # DET\n",
+    "        [-np.inf, -np.inf, -2, -3, -5],  # NOUN\n",
+    "        [-np.inf, -5, -2, -3, -2],  # VERB\n",
+    "    ]\n",
+    ")\n",
     "sentence = \"the aged bottle flies fast\""
    ]
   },
@@ -159,7 +171,7 @@
     }
    ],
    "source": [
-    "viterbi_logprobs(A,B, PI)"
+    "viterbi_logprobs(A, B, PI)"
    ]
   },
   {
@@ -169,7 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "num_to_tag = {0:'ADJ', 1:'ADV', 2:'DET', 3: 'NOUN', 4: 'VERB'}"
+    "num_to_tag = {0: \"ADJ\", 1: \"ADV\", 2: \"DET\", 3: \"NOUN\", 4: \"VERB\"}"
    ]
   },
   {
@@ -194,6 +206,1956 @@
     "for i in [2, 0, 3, 4, 1]:\n",
     "    print(num_to_tag[i])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfba3c68-8204-4267-b86b-e2e61a2c0f52",
+   "metadata": {},
+   "source": [
+    "# Plots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e3e5389b-be1e-48d5-81ab-e10d3b4a1979",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from visualization import plot_viterbi_path_binary, plot_viterbi_matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "aef3cec6-bb3e-41a0-ba43-b59a50fbf810",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "colorscale": [
+          [
+           0,
+           "rgb(3, 35, 51)"
+          ],
+          [
+           0.09090909090909091,
+           "rgb(13, 48, 100)"
+          ],
+          [
+           0.18181818181818182,
+           "rgb(53, 50, 155)"
+          ],
+          [
+           0.2727272727272727,
+           "rgb(93, 62, 153)"
+          ],
+          [
+           0.36363636363636365,
+           "rgb(126, 77, 143)"
+          ],
+          [
+           0.45454545454545453,
+           "rgb(158, 89, 135)"
+          ],
+          [
+           0.5454545454545454,
+           "rgb(193, 100, 121)"
+          ],
+          [
+           0.6363636363636364,
+           "rgb(225, 113, 97)"
+          ],
+          [
+           0.7272727272727273,
+           "rgb(246, 139, 69)"
+          ],
+          [
+           0.8181818181818182,
+           "rgb(251, 173, 60)"
+          ],
+          [
+           0.9090909090909091,
+           "rgb(246, 211, 70)"
+          ],
+          [
+           1,
+           "rgb(231, 250, 90)"
+          ]
+         ],
+         "showscale": false,
+         "text": [
+          [
+           0.8,
+           0,
+           0.1,
+           0.2,
+           0
+          ],
+          [
+           0,
+           0,
+           0.5,
+           0,
+           0.4
+          ],
+          [
+           0.1,
+           0.2,
+           0.2,
+           0.8,
+           0.1
+          ],
+          [
+           0.1,
+           0.8,
+           0.2,
+           0,
+           0.5
+          ]
+         ],
+         "textfont": {
+          "size": 20
+         },
+         "texttemplate": "%{text}",
+         "type": "heatmap",
+         "x": [
+          "The",
+          "blue",
+          "book",
+          "is",
+          "interesting"
+         ],
+         "y": [
+          "DET",
+          "N",
+          "V",
+          "ADJ"
+         ],
+         "z": [
+          [
+           10000.8,
+           0,
+           0.1,
+           0.2,
+           0
+          ],
+          [
+           0,
+           0,
+           10000.5,
+           0,
+           0.4
+          ],
+          [
+           0.1,
+           0.2,
+           0.2,
+           10000.8,
+           0.1
+          ],
+          [
+           0.1,
+           10000.8,
+           0.2,
+           0,
+           10000.5
+          ]
+         ]
+        }
+       ],
+       "layout": {
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "data = np.array(\n",
+    "    [\n",
+    "        # the blue book is interesting\n",
+    "        [0.8, 0.0, 0.1, 0.2, 0.0],  # DET\n",
+    "        [0.0, 0.0, 0.5, 0.0, 0.4],  # N\n",
+    "        [0.1, 0.2, 0.2, 0.8, 0.1],  # Verb\n",
+    "        [0.1, 0.8, 0.2, 0.0, 0.5],  # ADJ\n",
+    "    ]\n",
+    ")\n",
+    "backpointer = [0, 3, 1, 2, 3]\n",
+    "sentence = \"The blue book is interesting\"\n",
+    "tags = [\"DET\", \"N\", \"V\", \"ADJ\"]\n",
+    "\n",
+    "plot_viterbi_path_binary(data, backpointer, sentence, tags)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "e7f9aef7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "colorscale": [
+          [
+           0,
+           "rgb(3, 35, 51)"
+          ],
+          [
+           0.09090909090909091,
+           "rgb(13, 48, 100)"
+          ],
+          [
+           0.18181818181818182,
+           "rgb(53, 50, 155)"
+          ],
+          [
+           0.2727272727272727,
+           "rgb(93, 62, 153)"
+          ],
+          [
+           0.36363636363636365,
+           "rgb(126, 77, 143)"
+          ],
+          [
+           0.45454545454545453,
+           "rgb(158, 89, 135)"
+          ],
+          [
+           0.5454545454545454,
+           "rgb(193, 100, 121)"
+          ],
+          [
+           0.6363636363636364,
+           "rgb(225, 113, 97)"
+          ],
+          [
+           0.7272727272727273,
+           "rgb(246, 139, 69)"
+          ],
+          [
+           0.8181818181818182,
+           "rgb(251, 173, 60)"
+          ],
+          [
+           0.9090909090909091,
+           "rgb(246, 211, 70)"
+          ],
+          [
+           1,
+           "rgb(231, 250, 90)"
+          ]
+         ],
+         "type": "heatmap",
+         "x": [
+          "The",
+          "blue",
+          "book",
+          "is",
+          "interesting"
+         ],
+         "y": [
+          "DET",
+          "N",
+          "V",
+          "ADJ"
+         ],
+         "z": [
+          [
+           0.8,
+           0,
+           0.1,
+           0.2,
+           0
+          ],
+          [
+           0,
+           0,
+           0.5,
+           0,
+           0.4
+          ],
+          [
+           0.1,
+           0.2,
+           0.2,
+           0.8,
+           0.1
+          ],
+          [
+           0.1,
+           0.8,
+           0.2,
+           0,
+           0.5
+          ]
+         ]
+        }
+       ],
+       "layout": {
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "#E5ECF6",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "white",
+             "linecolor": "white",
+             "minorgridcolor": "white",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "#E5ECF6",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "white"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "#E5ECF6",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "radialaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "yaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           },
+           "zaxis": {
+            "backgroundcolor": "#E5ECF6",
+            "gridcolor": "white",
+            "gridwidth": 2,
+            "linecolor": "white",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "white"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           },
+           "bgcolor": "#E5ECF6",
+           "caxis": {
+            "gridcolor": "white",
+            "linecolor": "white",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "white",
+           "linecolor": "white",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "white",
+           "zerolinewidth": 2
+          }
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_viterbi_matrix(data, sentence, tags)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "994b4773",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/visualization.py
+++ b/visualization.py
@@ -1,0 +1,62 @@
+import numpy as np
+import plotly.graph_objects as go
+
+
+# Shows log probabilities in scale, legend is global for all the map
+def plot_viterbi_path_binary(
+    viterbi: np.array, backpointer: list, sentence: str, tags: str
+) -> None:
+    """
+    Shows the viterbi matrix result, highlighting the values that obtained the maximum probability at a given
+    time step.
+
+    Parameters
+    ----------
+    viterbi: viterbi algorithm matrix result. First element obtained after calling fuction: viterbi_logprobs
+    backpointer: viterbi algorithm backpointer result. Second element obtained after calling fuction: viterbi_logprobs
+    sentence: sentence which we have computed the probabilities against
+    tags: set of tags used in the algorithm
+
+    """
+    colors = viterbi.copy()
+
+    for i in range(len(backpointer)):
+        argmax_row = backpointer[i]
+        colors[argmax_row, i] += 10000
+
+    fig = go.Figure(
+        data=go.Heatmap(
+            z=colors,
+            x=[word for word in sentence.split(" ")],
+            y=[tag for tag in tags],
+            colorscale="Thermal",
+            text=viterbi,
+            texttemplate="%{text}",
+            textfont={"size": 20},
+            showscale=False,
+        )
+    )
+    fig.show(legend=False)
+
+
+# Shows log probabilities in scale, legend is global for all the map
+def plot_viterbi_matrix(viterbi: np.array, sentence: str, tags: str) -> None:
+    """
+    Shows the viterbi matrix result, painting the probabilities overall
+
+    Parameters
+    ----------
+    viterbi: viterbi algorithm matrix result. First element obtained after calling fuction: viterbi_logprobs
+    sentence: sentence which we have computed the probabilities against
+    tags: set of tags used in the algorithm
+
+    """
+    fig = go.Figure(
+        data=go.Heatmap(
+            z=viterbi,
+            x=[word for word in sentence.split(" ")],
+            y=[tag for tag in tags],
+            colorscale="Thermal",
+        )
+    )
+    fig.show(legend=False)

--- a/visualization.py
+++ b/visualization.py
@@ -2,7 +2,6 @@ import numpy as np
 import plotly.graph_objects as go
 
 
-# Shows log probabilities in scale, legend is global for all the map
 def plot_viterbi_path_binary(
     viterbi: np.array, backpointer: list, sentence: str, tags: str
 ) -> None:
@@ -39,7 +38,6 @@ def plot_viterbi_path_binary(
     fig.show(legend=False)
 
 
-# Shows log probabilities in scale, legend is global for all the map
 def plot_viterbi_matrix(viterbi: np.array, sentence: str, tags: str) -> None:
     """
     Shows the viterbi matrix result, painting the probabilities overall


### PR DESCRIPTION
* Add function that plots the viterbi "path" -> using the matrix output of the viterbi_log_probs algorithm (that still needs to be re-done).
* There are two functions:
   * plot_viterbi_path_binary -> binary because it paints mostly two colors (dark for non selected elements of the matrix, light for the elements selected at each step)
   * plot_viterbi_matrix -> no special highlighting, the colors are global (it can be interesting to show how the probability increases column by column, hence colors become lighter)
* Can be useful for the analysis part
* The library used is `plotly` and it is cool because it has interactivity 😎  (you can check the notebook with toy examples)